### PR TITLE
fix issue with charm config parsing default type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: false
 matrix:
   include:
-    - python: 3.4
     - python: 3.5
     - python: 3.6
+    - python: 3.8
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
-dist: trusty
-sudo: false
-matrix:
-  include:
-    - python: 3.5
-    - python: 3.6
-    - python: 3.8
+python:
+    - "3.5"
+    - "3.5"
+    - "3.8"
 script: make test

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+options:
+    test:
+        default: charm default
+        type: string

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -70,6 +70,9 @@ assert "extra overrides stdin" "'extra' ''"
 echo "" | run
 assert "empty stdin" "'' ''"
 
+echo "" | run --charm-config config.yaml
+assert "charm config" "'charm default' ''"
+
 (umask 022; run)
 assert_mode "default mode is 0666 - umask" 644
 

--- a/tests.py
+++ b/tests.py
@@ -74,6 +74,8 @@ def test_parse_charm_defaults():
             boolean:
                 default: false
                 type: boolean
+            no-type:
+                default: 1.0
 
     """)))
     assert defaults == {
@@ -81,6 +83,7 @@ def test_parse_charm_defaults():
         'int': 10,
         'float': 1.23,
         'boolean': False,
+        'no-type': '1.0',  # defaults to string
     }
 
 
@@ -150,6 +153,18 @@ def test_render_ctx_overrides_envfile():
     output = reify.render(
         TEMPLATE, {'env': {'TEST': 'ctx'}}, io.StringIO('TEST=envfile'), {})
     assert output == "'' 'ctx'\n"
+
+
+def test_render_charm_config():
+    charm_config = io.StringIO(textwrap.dedent("""
+        options:
+            test:
+                default: charm default
+                type: string
+    """))
+
+    output = reify.render(TEMPLATE, {}, None, {}, charm_config)
+    assert output == "'charm default' ''\n"
 
 
 def test_reify_function(tmpdir):


### PR DESCRIPTION
Includes slight refactor to make render() more useful as a library function.